### PR TITLE
Change item viewer api url so performance tasks can be loaded

### DIFF
--- a/SmarterBalanced.SampleItems/src/SmarterBalanced.SampleItems.Core/Repos/ItemViewRepo.cs
+++ b/SmarterBalanced.SampleItems/src/SmarterBalanced.SampleItems.Core/Repos/ItemViewRepo.cs
@@ -47,7 +47,10 @@ namespace SmarterBalanced.SampleItems.Core.Repos
             }
 
             string baseUrl = context.AppSettings.SettingsConfig.ItemViewerServiceURL;
-            return $"{baseUrl}/item/{digest.BankKey}-{digest.ItemKey}";
+            //For whomever refactors this to support performance task items.
+            //The item viewer service takes multiple items in the format
+            // {baseUrl}/items?ids={bankKey1-itemKey1},{bankKey2-itemKey2},{bankKey3-itemKey3}
+            return $"{baseUrl}/items?ids={digest.BankKey}-{digest.ItemKey}";
         }
 
         public ItemViewModel GetItemViewModel(

--- a/SmarterBalanced.SampleItems/src/SmarterBalanced.SampleItems.Web/Scripts/ItemPage.tsx
+++ b/SmarterBalanced.SampleItems/src/SmarterBalanced.SampleItems.Web/Scripts/ItemPage.tsx
@@ -149,7 +149,7 @@ namespace ItemPage {
 
         render() {
             let isaap = toiSAAP(this.props.accResourceGroups);
-            let ivsUrl: string = this.props.itemViewerServiceUrl.concat("?isaap=", isaap);
+            let ivsUrl: string = this.props.itemViewerServiceUrl.concat("&isaap=", isaap);
             var windowWidth = 600;
             const accText = (window.innerWidth < 350) ? "" : "Accessibility";
             const abtText = (window.innerWidth < windowWidth) ? "About" : "About This Item";


### PR DESCRIPTION
This changes the item viewer url to use the `\items?ids={some ids}` so we can load multiple items for performance task items.

WARNING: This will not work until the changes to the item viewer service that allow loading multiple items are deployed.